### PR TITLE
Azure SSO compatibility

### DIFF
--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -9,9 +9,14 @@ class Config
 {
     private const XML_PATH_ENABLED = 'admin/space48_sso/enabled';
     private const XML_PATH_SP_ENTITY_ID = 'admin/space48_sso/sp/entity_id';
+    private const XML_PATH_SP_STATIC_MAGENTO_ROLE_NAME = 'admin/space48_sso/sp/static_magento_role_name';
     private const XML_PATH_IDP_ENTITY_ID = 'admin/space48_sso/idp/entity_id';
     private const XML_PATH_IDP_SIGN_ON_URL = 'admin/space48_sso/idp/sign_on_url';
     private const XML_PATH_IDP_PUBLIC_CERTIFICATE = 'admin/space48_sso/idp/public_certificate';
+    private const XML_PATH_IDP_ATTRIBUTE_FIRSTNAME = 'admin/space48_sso/idp/attribute_firstname';
+    private const XML_PATH_IDP_ATTRIBUTE_LASTNAME = 'admin/space48_sso/idp/attribute_lastname';
+    private const XML_PATH_IDP_ATTRIBUTE_EMAIL = 'admin/space48_sso/idp/attribute_email';
+    private const XML_PATH_IDP_ATTRIBUTE_ROLE = 'admin/space48_sso/idp/attribute_role';
 
     /**
      * @var Url
@@ -34,6 +39,36 @@ class Config
     public function isEnabled(): bool
     {
         return $this->config->isSetFlag(self::XML_PATH_ENABLED);
+    }
+
+    public function getFirstNameAttributeName(): string
+    {
+        return $this->config->getValue(self::XML_PATH_IDP_ATTRIBUTE_FIRSTNAME) ?? 'firstname';
+    }
+
+    public function getLastNameAttributeName(): string
+    {
+        return $this->config->getValue(self::XML_PATH_IDP_ATTRIBUTE_LASTNAME) ?? 'lastname';
+    }
+
+    public function getEmailAttributeName(): string
+    {
+        return $this->config->getValue(self::XML_PATH_IDP_ATTRIBUTE_EMAIL) ?? 'email';
+    }
+
+    public function geRoleAttributeName(): string
+    {
+        return $this->config->getValue(self::XML_PATH_IDP_ATTRIBUTE_ROLE) ?? 'role';
+    }
+
+    public function hasStaticMagentoRoleName(): bool
+    {
+        return $this->config->getValue(self::XML_PATH_SP_STATIC_MAGENTO_ROLE_NAME) !== null;
+    }
+
+    public function getStaticMagentoRoleName(): string
+    {
+        return $this->config->getValue(self::XML_PATH_SP_STATIC_MAGENTO_ROLE_NAME);
     }
 
     public function getSAMLSettings(): array

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -8,6 +8,7 @@ use OneLogin\Saml2\Constants;
 class Config
 {
     private const XML_PATH_ENABLED = 'admin/space48_sso/enabled';
+    private const XML_PATH_SP_ENTITY_ID = 'admin/space48_sso/sp/entity_id';
     private const XML_PATH_IDP_ENTITY_ID = 'admin/space48_sso/idp/entity_id';
     private const XML_PATH_IDP_SIGN_ON_URL = 'admin/space48_sso/idp/sign_on_url';
     private const XML_PATH_IDP_PUBLIC_CERTIFICATE = 'admin/space48_sso/idp/public_certificate';
@@ -42,7 +43,7 @@ class Config
             'debug' => false,
             'baseurl' => $this->url->getBackendUrl(),
             'sp' => [
-                'entityId' => $this->url->getBackendUrl(),
+                'entityId' => $this->config->getValue(self::XML_PATH_SP_ENTITY_ID) ?? $this->url->getBackendUrl(),
                 'assertionConsumerService' => [
                     'url' => $this->url->getLoginCallbackUrl(),
                     'binding' => Constants::BINDING_HTTP_POST,

--- a/src/Service/Login.php
+++ b/src/Service/Login.php
@@ -127,15 +127,24 @@ class Login
 
         $user = $this->userManager->upsertUser(
             $auth->getNameId(),
-            $this->getRequiredAttribute($auth, 'email'),
-            $this->getRequiredAttribute($auth, 'firstname'),
-            $this->getRequiredAttribute($auth, 'lastname'),
-            $this->getRequiredAttribute($auth, 'role')
+            $this->getRequiredAttribute($auth, $this->config->getEmailAttributeName()),
+            $this->getRequiredAttribute($auth, $this->config->getFirstNameAttributeName()),
+            $this->getRequiredAttribute($auth, $this->config->getLastNameAttributeName()),
+            $this->getMagentoRoleName($auth)
         );
 
         $this->userManager->login($user);
 
         return $auth->redirectTo('', [], true);
+    }
+
+    private function getMagentoRoleName(Auth $auth): string
+    {
+        if ($this->config->hasStaticMagentoRoleName()) {
+            return $this->config->getStaticMagentoRoleName();
+        }
+
+        return $this->getRequiredAttribute($auth, $this->config->geRoleAttributeName());
     }
 
     /**

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -17,6 +17,10 @@
                         <label>Entity Identifier</label>
                         <comment>If empty, shop backend URL will be used</comment>
                     </field>
+                    <field id="static_magento_role_name" translate="label" type="text" sortOrder="20" showInDefault="1">
+                        <label>Static magento role name</label>
+                        <comment>If set, all SSO backend login users will be assigned to this role (eg. Administrators). If not set, IDP provided role will be used.</comment>
+                    </field>
                 </group>
                 <group id="idp" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="1">
                     <label>Identity Provider Configuration</label>
@@ -34,6 +38,22 @@
                     <field id="public_certificate" translate="label" type="textarea" sortOrder="30" showInDefault="1">
                         <label>Public Certificate</label>
                         <validate>required-entry</validate>
+                    </field>
+                    <field id="attribute_firstname" translate="label" sortOrder="40" showInDefault="1">
+                        <label>SAML attribute name FirstName</label>
+                        <comment>Default: firstname</comment>
+                    </field>
+                    <field id="attribute_lastname" translate="label" sortOrder="50" showInDefault="1">
+                        <label>SAML attribute name LastName</label>
+                        <comment>Default: lastname</comment>
+                    </field>
+                    <field id="attribute_email" translate="label" sortOrder="60" showInDefault="1">
+                        <label>SAML attribute name Email</label>
+                        <comment>Default: email</comment>
+                    </field>
+                    <field id="attribute_role" translate="label" sortOrder="70" showInDefault="1">
+                        <label>SAML attribute name Role</label>
+                        <comment>The value for this attribute will be used as magento role for the user. Default: role</comment>
                     </field>
                 </group>
             </group>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -8,7 +8,17 @@
                     <label>Enable</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <group id="idp" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="1">
+                <group id="sp" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="1">
+                    <label>Service Provider Configuration</label>
+                    <depends>
+                        <field id="admin/space48_sso/enabled">1</field>
+                    </depends>
+                    <field id="entity_id" translate="label" type="text" sortOrder="10" showInDefault="1">
+                        <label>Entity Identifier</label>
+                        <comment>If empty, shop backend URL will be used</comment>
+                    </field>
+                </group>
+                <group id="idp" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="0" showInStore="1">
                     <label>Identity Provider Configuration</label>
                     <depends>
                         <field id="admin/space48_sso/enabled">1</field>


### PR DESCRIPTION
Added possibility to configure service provider application id.
Azure requires a SP-entity_id like `api://uuid` instead of the magento backend URL

I also made the SAML attribute names configurable so that it is easier to connect with a IDP (azure for example uses a attribute name like `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname` instead of hard coded `firstname`)

@tgerulaitis please review, thanks