### PR TITLE
AADSTS75011: Azure-AD login with 'OneTimePasscode'

### DIFF
--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -77,6 +77,9 @@ class Config
             'strict' => true,
             'debug' => false,
             'baseurl' => $this->url->getBackendUrl(),
+            'security' => [
+                'requestedAuthnContext' => false,
+            ],
             'sp' => [
                 'entityId' => $this->config->getValue(self::XML_PATH_SP_ENTITY_ID) ?? $this->url->getBackendUrl(),
                 'assertionConsumerService' => [


### PR DESCRIPTION
When a guest in AzureAD logs in with one time passcode which he received by email from azure during login, SSO is not possible:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/106059119/178675878-14afe206-5cca-44f1-a894-becd468dccec.png)

Same issue as described here: https://github.com/derricksmith/phpsaml/issues/21 , applied solution described here: https://github.com/derricksmith/phpsaml/issues/21#issuecomment-709593989

Example SAMLRequest before the change (has **RequestedAuthnContext**):
```
<samlp:AuthnRequest
    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
    ID="ONELOGIN_8b3132c81a254efd18d5f7b7a05892151d41daf3"
    Version="2.0"

    IssueInstant="2022-07-13T06:43:53Z"
    Destination="https://login.microsoftonline.com/72997770-*******************/saml2"
    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
    AssertionConsumerServiceURL="https://***************/admin/sso/login/process/">
    <saml:Issuer>api://2134ae91-*************************</saml:Issuer>
    <samlp:NameIDPolicy
        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
        AllowCreate="true" />
    <samlp:RequestedAuthnContext Comparison="exact">
        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
    </samlp:RequestedAuthnContext>
</samlp:AuthnRequest>
```

Example SAMLRequest with/after this change:
```
<samlp:AuthnRequest
    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
    ID="ONELOGIN_8d8f5150de8db2d96e6d3bbdf2aac6462ee038b5"
    Version="2.0"

    IssueInstant="2022-07-13T07:12:21Z"
    Destination="https://login.microsoftonline.com/72997770-********************/saml2"
    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
    AssertionConsumerServiceURL="https://***************/admin/sso/login/process/">
    <saml:Issuer>api://2134ae91-*****************</saml:Issuer>
    <samlp:NameIDPolicy
        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
        AllowCreate="true" />
</samlp:AuthnRequest>
```

This should not impact the security as the SAMLRequest is not signed by this plugin and can therefore be modified by the end user.

